### PR TITLE
Give flush_interval a sane value

### DIFF
--- a/blog.ini
+++ b/blog.ini
@@ -1,7 +1,7 @@
 [blog/debug]
 output = /tmp/$COMPANY-$APP_NAME.log
 category.All=All
-flush_interval=0
+flush_interval=10
 file_size_limit=25M
 file_size_limit_retain=5F
 enabled=1


### PR DESCRIPTION
flush_interval=0 can cause some serious performance issues and IO load depending your use.  Since this repository looks like it will be used for deployment I recommend keeping this value at its default level of 10 then only reduce to 0 when needed(its almost never needed to be 0).